### PR TITLE
Add XML::XPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,16 @@ References:
 
 ## XPATH 1.0
 
-... TODO ...
+The initial draft is capable to tokenize and parse XPATH 1.0 expressions. The
+AST is in flux, it will evolve as evaluation is implemented.
 
 References:
 
 - <https://www.w3.org/TR/xpath-10/>
+
+XPATH 2.0 and later isn't planned for the time being. The spec is far more
+complex: the model is different, XSD data types, control-flow, ... it would
+require to implement most of XQUERY 1.0.
 
 ## LICENSE
 

--- a/spec/xpath/parser_spec.cr
+++ b/spec/xpath/parser_spec.cr
@@ -390,6 +390,33 @@ class XML::XPath::ParserTest < Minitest::Test
       )
   end
 
+  def test_filter_expressions
+    assert_parses %(preceding::foo[1]),
+      Path.relative([
+        Step.new(Axis::Preceding, NodeTest::Name.new("foo"), [Literal.number(1)] of Expr)
+      ])
+
+    assert_parses %(preceding::foo[1][2]),
+      Path.relative([
+        Step.new(Axis::Preceding, NodeTest::Name.new("foo"), [
+          Literal.number(1),
+          Literal.number(2),
+        ] of Expr)
+      ])
+
+    assert_parses %((preceding::foo)[1]),
+      FilterExpr.new(
+        Path.relative([Step.new(Axis::Preceding, NodeTest::Name.new("foo"))]),
+        [Literal.number(1)] of Expr
+      )
+
+    assert_parses %((preceding::foo)[1][2]),
+      FilterExpr.new(
+        Path.relative([Step.new(Axis::Preceding, NodeTest::Name.new("foo"))]),
+        [Literal.number(1), Literal.number(2)] of Expr
+      )
+  end
+
   def assert_parses(input, expected = nil, message = nil, file = __FILE__, line = __LINE__)
     lexer = Lexer.new(input)
     parser = Parser.new(lexer)

--- a/spec/xpath/parser_spec.cr
+++ b/spec/xpath/parser_spec.cr
@@ -1,0 +1,399 @@
+require "minitest/autorun"
+require "../../src/xpath/parser"
+
+class XML::XPath::ParserTest < Minitest::Test
+  def test_unabbreviated_syntax
+    assert_parses %(child::para),
+      Path.relative([Step.new(Axis::Child, NodeTest::Name.new("para"))])
+
+    assert_parses %(child::*),
+      Path.relative([Step.new(Axis::Child, NodeTest::Any.new)])
+
+    assert_parses %(child::text()),
+      Path.relative([Step.new(Axis::Child, NodeTest::Text.new)])
+
+    assert_parses %(child::node()),
+      Path.relative([Step.new(Axis::Child, NodeTest::Node.new)])
+
+    assert_parses %(attribute::name),
+      Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("name"))])
+
+    assert_parses %(attribute::*),
+      Path.relative([Step.new(Axis::Attribute, NodeTest::Any.new)])
+
+    assert_parses %(descendant::para),
+      Path.relative([Step.new(Axis::Descendant, NodeTest::Name.new("para"))])
+
+    assert_parses %(ancestor::div),
+      Path.relative([Step.new(Axis::Ancestor, NodeTest::Name.new("div"))])
+
+    assert_parses %(ancestor-or-self::div),
+      Path.relative([Step.new(Axis::AncestorOrSelf, NodeTest::Name.new("div"))])
+
+    assert_parses %(descendant-or-self::para),
+      Path.relative([Step.new(Axis::DescendantOrSelf, NodeTest::Name.new("para"))])
+
+    assert_parses %(self::para),
+      Path.relative([Step.new(Axis::Self, NodeTest::Name.new("para"))])
+
+    assert_parses %(child::chapter/descendant::para),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("chapter")),
+        Step.new(Axis::Descendant, NodeTest::Name.new("para")),
+      ])
+
+    assert_parses %(child::*/child::para),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Any.new),
+        Step.new(Axis::Child, NodeTest::Name.new("para")),
+      ])
+
+    assert_parses %(/),
+      Path.absolute
+
+    assert_parses %(/descendant::para),
+      Path.absolute([
+        Step.new(Axis::Descendant, NodeTest::Name.new("para")),
+      ])
+
+    assert_parses %(/descendant::olist/child::item),
+      Path.absolute([
+        Step.new(Axis::Descendant, NodeTest::Name.new("olist")),
+        Step.new(Axis::Child, NodeTest::Name.new("item")),
+      ])
+
+    assert_parses %(child::para[position()=1]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(1)),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::para[position()=last()]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), FunctionCall.new("last")),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::para[position()=last()-1]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(
+            Operator::Equal,
+            FunctionCall.new("position"),
+            BinaryExpr.new(Operator::Sub, FunctionCall.new("last"), Literal.number(1)),
+          ),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::para[position()>1]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(Operator::GreaterThan, FunctionCall.new("position"), Literal.number(1)),
+        ] of Expr)
+      ])
+
+    assert_parses %(following-sibling::chapter[position()=1]),
+      Path.relative([
+        Step.new(Axis::FollowingSibling, NodeTest::Name.new("chapter"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(1)),
+        ] of Expr)
+      ])
+
+    assert_parses %(preceding-sibling::chapter[position()=1]),
+      Path.relative([
+        Step.new(Axis::PrecedingSibling, NodeTest::Name.new("chapter"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(1)),
+        ] of Expr)
+      ])
+
+    assert_parses %(/descendant::figure[position()=42]),
+      Path.absolute([
+        Step.new(Axis::Descendant, NodeTest::Name.new("figure"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(42)),
+        ] of Expr)
+      ])
+
+    assert_parses %(/child::doc/child::chapter[position()=5]/child::section[position()=2]),
+      Path.absolute([
+        Step.new(Axis::Child, NodeTest::Name.new("doc")),
+        Step.new(Axis::Child, NodeTest::Name.new("chapter"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(5)),
+        ] of Expr),
+        Step.new(Axis::Child, NodeTest::Name.new("section"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(2)),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::para[attribute::type="warning"]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(Operator::Equal, Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("type"))]), Literal.string("warning")),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::para[attribute::type='warning'][position()=5]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(Operator::Equal, Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("type"))]), Literal.string("warning")),
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(5)),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::para[position()=5][attribute::type="warning"]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), Literal.number(5)),
+          BinaryExpr.new(
+            Operator::Equal,
+            Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("type"))]),
+            Literal.string("warning")
+        ),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::chapter[child::title='Introduction']),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("chapter"), [
+          BinaryExpr.new(
+            Operator::Equal,
+            Path.relative([Step.new(Axis::Child, NodeTest::Name.new("title"))]),
+            Literal.string("Introduction")),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::chapter[child::title]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("chapter"), [
+          Path.relative([Step.new(Axis::Child, NodeTest::Name.new("title"))]),
+        ] of Expr)
+      ])
+
+    assert_parses %(child::*[self::chapter or self::appendix]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Any.new, [
+          BinaryExpr.new(
+            Operator::Or,
+            Path.relative([Step.new(Axis::Self, NodeTest::Name.new("chapter"))]),
+            Path.relative([Step.new(Axis::Self, NodeTest::Name.new("appendix"))])
+          )
+        ] of Expr)
+      ])
+
+    assert_parses %(child::*[self::chapter or self::appendix][position()=last()]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Any.new, [
+          BinaryExpr.new(
+            Operator::Or,
+            Path.relative([Step.new(Axis::Self, NodeTest::Name.new("chapter"))]),
+            Path.relative([Step.new(Axis::Self, NodeTest::Name.new("appendix"))])
+          ),
+          BinaryExpr.new(Operator::Equal, FunctionCall.new("position"), FunctionCall.new("last")),
+        ] of Expr)
+      ])
+  end
+
+  def test_abbreviated_syntax
+    assert_parses %(para),
+      Path.relative([Step.new(Axis::Child, NodeTest::Name.new("para"))])
+
+    assert_parses %(*),
+      Path.relative([Step.new(Axis::Child, NodeTest::Any.new)])
+
+    assert_parses %(text()),
+      Path.relative([Step.new(Axis::Child, NodeTest::Text.new)])
+
+    assert_parses %(@name),
+      Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("name"))])
+
+    assert_parses %(@*),
+      Path.relative([Step.new(Axis::Attribute, NodeTest::Any.new)])
+
+    assert_parses %(para[1]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [Literal.number(1)] of Expr)
+      ])
+
+    assert_parses %(para[last()]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [FunctionCall.new("last")] of Expr)
+      ])
+
+    assert_parses %(*/para),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Any.new),
+        Step.new(Axis::Child, NodeTest::Name.new("para")),
+      ])
+
+    assert_parses %(/doc/chapter[5]/section[2]),
+      Path.absolute([
+        Step.new(Axis::Child, NodeTest::Name.new("doc")),
+        Step.new(Axis::Child, NodeTest::Name.new("chapter"), [Literal.number(5)] of Expr),
+        Step.new(Axis::Child, NodeTest::Name.new("section"), [Literal.number(2)] of Expr),
+      ])
+
+    assert_parses %(chapter//para),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("chapter")),
+        Step.abbreviated,
+        Step.new(Axis::Child, NodeTest::Name.new("para")),
+      ])
+
+    assert_parses %(//para),
+      Path.absolute([
+        Step.abbreviated,
+        Step.new(Axis::Child, NodeTest::Name.new("para")),
+      ])
+
+    assert_parses %(//olist/item),
+      Path.absolute([
+        Step.abbreviated,
+        Step.new(Axis::Child, NodeTest::Name.new("olist")),
+        Step.new(Axis::Child, NodeTest::Name.new("item")),
+      ])
+
+    assert_parses %(.),
+      Path.relative([Step.new(Axis::Self, NodeTest::Node.new)])
+
+    assert_parses %(.//para),
+      Path.relative([
+        Step.new(Axis::Self, NodeTest::Node.new),
+        Step.abbreviated,
+        Step.new(Axis::Child, NodeTest::Name.new("para")),
+      ])
+
+    assert_parses %(..),
+      Path.relative([Step.new(Axis::Parent, NodeTest::Node.new)])
+
+    assert_parses %(../@lang),
+      Path.relative([
+        Step.new(Axis::Parent, NodeTest::Node.new),
+        Step.new(Axis::Attribute, NodeTest::Name.new("lang")),
+      ])
+
+    assert_parses %(para[@type="warning"]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(
+            Operator::Equal,
+            Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("type"))]),
+            Literal.string("warning"),
+          ),
+        ] of Expr),
+      ])
+
+    assert_parses %(para[@type="warning"][5]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          BinaryExpr.new(
+            Operator::Equal,
+            Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("type"))]),
+            Literal.string("warning"),
+          ),
+          Literal.number(5),
+        ] of Expr),
+      ])
+
+    assert_parses %(para[5][@type="warning"]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("para"), [
+          Literal.number(5),
+          BinaryExpr.new(
+            Operator::Equal,
+            Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("type"))]),
+            Literal.string("warning"),
+          ),
+        ] of Expr),
+      ])
+
+    assert_parses %(chapter[title="Introduction"]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("chapter"), [
+          BinaryExpr.new(
+            Operator::Equal,
+            Path.relative([Step.new(Axis::Child, NodeTest::Name.new("title"))]),
+            Literal.string("Introduction"),
+          ),
+        ] of Expr),
+      ])
+
+    assert_parses %(chapter[title]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("chapter"), [
+          Path.relative([Step.new(Axis::Child, NodeTest::Name.new("title"))]),
+        ] of Expr),
+      ])
+
+    assert_parses %(employee[@secretary and @assistant]),
+      Path.relative([
+        Step.new(Axis::Child, NodeTest::Name.new("employee"), [
+          BinaryExpr.new(
+            Operator::And,
+            Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("secretary"))]),
+            Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("assistant"))]),
+          ),
+        ] of Expr),
+      ])
+  end
+
+  def test_expressions
+    assert_parses %(@value > 10),
+      BinaryExpr.new(
+        Operator::GreaterThan,
+        Path.relative([Step.new(Axis::Attribute, NodeTest::Name.new("value"))]),
+        Literal.number(10)
+      )
+
+    assert_parses %($x='foo'),
+      BinaryExpr.new(Operator::Equal, VariableReference.new("x"), Literal.string("foo"))
+
+    assert_parses %($x!='foo'),
+      BinaryExpr.new(Operator::NotEqual, VariableReference.new("x"), Literal.string("foo"))
+
+    assert_parses %(not($x!='foo')),
+      FunctionCall.new("not", [
+        BinaryExpr.new(Operator::NotEqual, VariableReference.new("x"), Literal.string("foo"))
+      ] of Expr)
+
+    assert_parses %(3 > 2 > 1),
+      BinaryExpr.new(
+        Operator::GreaterThan,
+        BinaryExpr.new(
+          Operator::GreaterThan,
+          Literal.number(3),
+          Literal.number(2),
+        ),
+        Literal.number(1),
+      )
+
+    assert_parses %((3 > 2) > 1),
+      BinaryExpr.new(
+        Operator::GreaterThan,
+        BinaryExpr.new(
+          Operator::GreaterThan,
+          Literal.number(3),
+          Literal.number(2),
+        ),
+        Literal.number(1),
+      )
+
+    assert_parses %(3 > (2 > 1)),
+      BinaryExpr.new(
+        Operator::GreaterThan,
+        Literal.number(3),
+        BinaryExpr.new(
+          Operator::GreaterThan,
+          Literal.number(2),
+          Literal.number(1),
+        ),
+      )
+  end
+
+  def assert_parses(input, expected = nil, message = nil, file = __FILE__, line = __LINE__)
+    lexer = Lexer.new(input)
+    parser = Parser.new(lexer)
+    actual = parser.parse
+    assert_equal expected, actual, message, file, line
+  end
+end

--- a/src/sax/reader.cr
+++ b/src/sax/reader.cr
@@ -137,6 +137,12 @@ module XML
         true
       end
 
+      def skip_s : Nil
+        while (char = current?) && Chars.s?(char)
+          consume?
+        end
+      end
+
       # As per <https://www.w3.org/TR/xml11/#sec-line-ends>.
       def normalize_line_endings(char)
         unless @normalize_eol.never?

--- a/src/xpath/ast.cr
+++ b/src/xpath/ast.cr
@@ -129,40 +129,19 @@ module XML
       def_equals @expr
     end
 
-    abstract struct Value
-    end
-
-    struct StringValue < Value
-      getter value : String
-
-      def initialize(@value)
-      end
-
-      def_equals @value
-    end
-
-    struct NumberValue < Value
-      getter value : Float64
-
-      def self.new(value : Int::Signed)
-        new value.to_f
-      end
-
-      def initialize(@value)
-      end
-
-      def_equals @value
-    end
-
     class Literal < Expr
-      getter value : Value
+      getter value : Float64 | String
 
-      def self.number(value) : self
-        new NumberValue.new(value)
+      def self.number(value : Int::Signed) : self
+        new value.to_f64
       end
 
-      def self.string(value) : self
-        new StringValue.new(value)
+      def self.number(value : Float64) : self
+        new value
+      end
+
+      def self.string(value : String) : self
+        new value
       end
 
       def initialize(@value)
@@ -192,12 +171,12 @@ module XML
 
     class FilterExpr < Expr
       getter expr : Expr
-      getter! predicate : Expr
+      getter! predicates : Array(Expr)
 
-      def initialize(@expr, @predicate = nil)
+      def initialize(@expr, @predicates = nil)
       end
 
-      def_equals @expr, @predicate
+      def_equals @expr, @predicates
     end
 
     class Path < Expr

--- a/src/xpath/ast.cr
+++ b/src/xpath/ast.cr
@@ -1,0 +1,259 @@
+module XML
+  module XPath
+    enum Axis
+      Ancestor = 1
+      AncestorOrSelf
+      Attribute
+      Child
+      Descendant
+      DescendantOrSelf
+      Following
+      FollowingSibling
+      Namespace
+      Parent
+      Preceding
+      PrecedingSibling
+      Self
+
+      def self.from(name : String) : self
+        case name
+        when "ancestor"           then Ancestor
+        when "ancestor-or-self"   then AncestorOrSelf
+        when "attribute"          then Attribute
+        when "child"              then Child
+        when "descendant"         then Descendant
+        when "descendant-or-self" then DescendantOrSelf
+        when "following"          then Following
+        when "following-sibling"  then FollowingSibling
+        when "namespace"          then Namespace
+        when "parent"             then Parent
+        when "preceding"          then Preceding
+        when "preceding-sibling"  then PrecedingSibling
+        when "self"               then Self
+        else raise "BUG: invalid axis name"
+        end
+      end
+    end
+
+    enum Operator
+      Add = 1
+      Sub
+      Mul
+      Div
+      Mod
+      Or
+      And
+      Equal
+      NotEqual
+      LowerThan
+      LowerThanOrEqual
+      GreaterThan
+      GreaterThanOrEqual
+
+      def self.from(value : String) : self
+        case value
+        when "+"   then Add
+        when "-"   then Sub
+        when "*"   then Mul
+        when "div" then Div
+        when "mod" then Mod
+        when "or"  then Or
+        when "and" then And
+        when "="   then Equal
+        when "!="  then NotEqual
+        when "<"   then LowerThan
+        when "<="  then LowerThanOrEqual
+        when ">"   then GreaterThan
+        when ">="  then GreaterThanOrEqual
+        else raise "BUG: invalid operator"
+        end
+      end
+    end
+
+    abstract struct NodeTest
+      struct Any < NodeTest
+      end
+
+      struct Node < NodeTest
+      end
+
+      struct Text < NodeTest
+      end
+
+      struct Comment < NodeTest
+      end
+
+      struct ProcessingInstruction < NodeTest
+        getter? name : String?
+
+        def initialize(@name)
+        end
+
+        def_equals @name
+      end
+
+      struct Name < NodeTest
+        getter name : String
+
+        def initialize(@name)
+        end
+
+        def_equals @name
+      end
+    end
+
+    abstract class Expr
+    end
+
+    class BinaryExpr < Expr
+      getter operator : Operator
+      getter lhs : Expr
+      getter rhs : Expr
+
+      def initialize(@operator, @lhs, @rhs)
+      end
+
+      def_equals @operator, @lhs, @rhs
+    end
+
+    class UnaryExpr < Expr
+      getter expr : Expr
+
+      def initialize(@expr)
+      end
+
+      def operator : Operator
+        Operator::Sub
+      end
+
+      def_equals @expr
+    end
+
+    abstract struct Value
+    end
+
+    struct StringValue < Value
+      getter value : String
+
+      def initialize(@value)
+      end
+
+      def_equals @value
+    end
+
+    struct NumberValue < Value
+      getter value : Float64
+
+      def self.new(value : Int::Signed)
+        new value.to_f
+      end
+
+      def initialize(@value)
+      end
+
+      def_equals @value
+    end
+
+    class Literal < Expr
+      getter value : Value
+
+      def self.number(value) : self
+        new NumberValue.new(value)
+      end
+
+      def self.string(value) : self
+        new StringValue.new(value)
+      end
+
+      def initialize(@value)
+      end
+
+      def_equals @value
+    end
+
+    class FunctionCall < Expr
+      getter name : String
+      getter! arguments : Array(Expr)
+
+      def initialize(@name, @arguments = nil)
+      end
+
+      def_equals @name, @arguments
+    end
+
+    class VariableReference < Expr
+      getter name : String
+
+      def initialize(@name)
+      end
+
+      def_equals @name
+    end
+
+    class FilterExpr < Expr
+      getter expr : Expr
+      getter! predicate : Expr
+
+      def initialize(@expr, @predicate = nil)
+      end
+
+      def_equals @expr, @predicate
+    end
+
+    class Path < Expr
+      enum Kind
+        Absolute
+        Relative
+        Filter
+      end
+
+      getter kind : Kind
+      getter! filter : Expr
+      getter! steps : Array(Step)
+
+      def self.absolute(steps = nil)
+        new(:absolute, nil, steps)
+      end
+
+      def self.relative(steps)
+        new(:relative, nil, steps)
+      end
+
+      def self.filter(expr, steps)
+        new(:filter, expr, steps)
+      end
+
+      def initialize(@kind, @filter, @steps)
+      end
+
+      def absolute? : Bool
+        @kind.absolute?
+      end
+
+      def root? : Bool
+        absolute? && @steps.nil?
+      end
+
+      def relative? : Bool
+        @kind.relative?
+      end
+
+      def_equals @kind, @filter, @steps
+    end
+
+    class Step < Expr
+      def self.abbreviated : self
+        new(Axis::DescendantOrSelf, NodeTest::Node.new, nil)
+      end
+
+      getter axis : Axis
+      getter node_test : NodeTest
+      getter! predicates : Array(Expr)
+
+      def initialize(@axis, @node_test, @predicates = nil)
+      end
+
+      def_equals @axis, @node_test, @predicates
+    end
+  end
+end

--- a/src/xpath/ast.cr
+++ b/src/xpath/ast.cr
@@ -1,3 +1,6 @@
+# Copyright 2025 Julien PORTALIER
+# Distributed under the Apache-2.0 LICENSE
+
 module XML
   module XPath
     enum Axis

--- a/src/xpath/lexer.cr
+++ b/src/xpath/lexer.cr
@@ -1,0 +1,262 @@
+require "../chars"
+require "../sax/reader"
+
+module XML
+  module XPath
+    class SyntaxError < Exception
+      getter location : Location
+
+      def initialize(message : String, @location : Location)
+        super "#{message} at #{location}"
+      end
+    end
+
+    # :nodoc:
+    class Lexer
+      enum Kind
+        Lparen
+        Rparen
+        Lsqb
+        Rsqb
+        At
+        Comma
+        Dot
+        DotDot
+        Colon
+        ColonColon
+        Slash
+        SlashSlash
+        Operator
+        Star
+        Number
+        Literal
+        VariableReference
+        NodeType
+        FunctionName
+        AxisName
+        Name
+      end
+
+      # :nodoc:
+      struct Token
+        getter kind : Kind
+        getter! value : String
+
+        def initialize(@kind : Kind, @value : String? = nil)
+        end
+
+        def inspect(io : IO)
+          io << '{'
+          kind.to_s(io)
+          if value = @value
+            io << ',' << ' '
+            value.inspect(io)
+          end
+          io << '}'
+        end
+      end
+
+      def self.new(string : String) : self
+        new SAX::Reader.new(IO::Memory.new(string))
+      end
+
+      def self.new(io : IO) : self
+        new SAX::Reader.new(io)
+      end
+
+      getter start_location : Location
+      @preceding : Token?
+
+      # :nodoc:
+      def initialize(@reader : SAX::Reader)
+        @start_location = @reader.location
+      end
+
+      def location : Location
+        @reader.location
+      end
+
+      def next? : Token?
+        @reader.skip_s
+        @start_location = @reader.location
+
+        @preceding =
+          case char = @reader.consume?
+          when nil
+            # EOF
+          when '('
+            Token.new(:Lparen)
+          when ')'
+            Token.new(:Rparen)
+          when '['
+            Token.new(:Lsqb)
+          when ']'
+            Token.new(:Rsqb)
+          when '@'
+            Token.new(:At)
+          when ','
+            Token.new(:Comma)
+          when '.'
+            lex_single_or_double(char, :Dot, :DotDot)
+          when ':'
+            lex_single_or_double(char, :Colon, :ColonColon)
+          when '/'
+            lex_single_or_double(char, :Slash, :SlashSlash)
+          when '|'
+            Token.new(:Operator, "|")
+          when '*'
+            lex_star_and_disambiguate
+          when '+'
+            Token.new(:Operator, "+")
+          when '-'
+            Token.new(:Operator, "-")
+          when '='
+            Token.new(:Operator, "=")
+          when '!'
+            expect '='
+            Token.new(:Operator, "!=")
+          when '<'
+            lex_than_or_equal("<", "<=")
+          when '>'
+            lex_than_or_equal(">", ">=")
+          when '"', '\''
+            lex_literal(char)
+          when '0'..'9'
+            lex_number(char)
+          when '$'
+            lex_variable_reference
+          else
+            lex_name_and_disambiguate(char)
+          end
+      end
+
+      protected def lex_single_or_double(char, single : Kind, double : Kind)
+        if @reader.current? == char
+          @reader.consume?
+          Token.new(double)
+        else
+          Token.new(single)
+        end
+      end
+
+      protected def lex_than_or_equal(than, than_or_equal)
+        if @reader.peek == '='
+          @reader.consume?
+          Token.new(:Operator, than_or_equal)
+        else
+          Token.new(:Operator, than)
+        end
+      end
+
+      protected def lex_star_and_disambiguate
+        case @preceding.try(&.kind)
+        when Kind::At, Kind::ColonColon, Kind::Lparen, Kind::Lsqb, Kind::Comma, Kind::Operator, nil
+          Token.new(:Star)
+        else
+          Token.new(:Operator, "*")
+        end
+      end
+
+      protected def lex_number(char)
+        dot = false
+
+        value = String.build do |str|
+          str << char
+
+          while char = @reader.current?
+            case char
+            when '0'..'9'
+              # ok
+            when '.'
+              syntax_error "Unexpected '.'" if dot
+              dot = true
+            else
+              break
+            end
+            str << char
+            @reader.consume?
+          end
+        end
+        Token.new(:Number, value)
+      end
+
+      protected def lex_literal(quote)
+        value = String.build do |str|
+          while char = @reader.current?
+            @reader.consume?
+            break if char == quote
+            str << char
+          end
+        end
+        Token.new(:Literal, value)
+      end
+
+      protected def lex_variable_reference
+        value = lex_name(@reader.consume?)
+        Token.new(:VariableReference, value)
+      end
+
+      protected def lex_name_and_disambiguate(char)
+        value = lex_name(char)
+
+        case @preceding.try(&.kind)
+        when Kind::At, Kind::ColonColon, Kind::Lparen, Kind::Lsqb, Kind::Comma, Kind::Operator
+          # not an OperatorName
+        else
+          case value
+          when "and", "or", "mod", "div"
+            return Token.new(:Operator, value)
+          end
+        end
+
+        @reader.skip_s
+
+        case @reader.current?
+        when '('
+          case value
+          when "comment", "node", "processing-instruction", "text"
+            return Token.new(:NodeType, value)
+          else
+            return Token.new(:FunctionName, value)
+          end
+        when ':'
+          if @reader.peek == ':'
+            case value
+            when "ancestor", "ancestor-or-self", "attribute", "child", "descendant",
+                 "descendant-or-self", "following", "following-sibling", "namespace",
+                 "parent", "preceding", "preceding-sibling", "self"
+              return Token.new(:AxisName, value)
+            else
+              syntax_error "Expected AxisName"
+            end
+          end
+        end
+
+        Token.new(:Name, value)
+      end
+
+      protected def lex_name(char) : String
+        # char = @reader.current
+        # syntax_error "Expected NameStartChar" unless Chars.name_start?(char)
+
+        String.build do |str|
+          str << char
+
+          while (char = @reader.current?) && Chars.name?(char)
+            break if char == ':' && @reader.peek == ':'
+            str << char
+            @reader.consume?
+          end
+        end
+      end
+
+      protected def expect(char)
+        syntax_error "Expected #{char.inspect}" unless @reader.consume? == char
+      end
+
+      protected def syntax_error(message, location = @start_location)
+        raise SyntaxError.new(message, location)
+      end
+    end
+  end
+end

--- a/src/xpath/lexer.cr
+++ b/src/xpath/lexer.cr
@@ -1,3 +1,6 @@
+# Copyright 2025 Julien PORTALIER
+# Distributed under the Apache-2.0 LICENSE
+
 require "../chars"
 require "../sax/reader"
 

--- a/src/xpath/parser.cr
+++ b/src/xpath/parser.cr
@@ -209,10 +209,10 @@ module XML
 
       protected def parse_filter_expr
         expr = parse_primary_expr
+        predicates = parse_predicates?
 
-        if (tok = @lexer.current?) && (tok.kind == Kind::Lsqb)
-          predicate = parse_predicate
-          FilterExpr.new(expr, predicate)
+        if predicates
+          FilterExpr.new(expr, predicates)
         else
           expr
         end

--- a/src/xpath/parser.cr
+++ b/src/xpath/parser.cr
@@ -1,3 +1,6 @@
+# Copyright 2025 Julien PORTALIER
+# Distributed under the Apache-2.0 LICENSE
+
 require "./ast"
 require "./lexer"
 

--- a/src/xpath/parser.cr
+++ b/src/xpath/parser.cr
@@ -1,0 +1,304 @@
+require "./ast"
+require "./lexer"
+
+module XML
+  module XPath
+    class Parser
+      alias Kind = Lexer::Kind
+
+      def initialize(@lexer : Lexer)
+      end
+
+      def parse
+        parse_or_expr
+      end
+
+      protected def parse_or_expr
+        parse_binary_expr("or", proc: ->parse_and_expr)
+      end
+
+      protected def parse_and_expr
+        parse_binary_expr("and", proc: ->parse_equality_expr)
+      end
+
+      protected def parse_equality_expr
+        parse_binary_expr("=", "!=", proc: ->parse_relational_expr)
+      end
+
+      protected def parse_relational_expr
+        parse_binary_expr("<", "<=", ">", ">=", proc: ->parse_additive_expr)
+      end
+
+      protected def parse_additive_expr
+        parse_binary_expr("+", "-", proc: ->parse_multiplicative_expr)
+      end
+
+      protected def parse_multiplicative_expr
+        parse_binary_expr("*", "div", "mod", proc: ->parse_unary_expr)
+      end
+
+      protected def parse_unary_expr
+        if @lexer.operator?("-")
+          expr = parse_unary_expr
+          UnaryExpr.new(expr)
+        else
+          parse_union_expr
+        end
+      end
+
+      protected def parse_union_expr
+        parse_binary_expr("|", proc: ->parse_path_expr)
+      end
+
+      protected def parse_binary_expr(*operators : String, proc : Proc(Expr))
+        expr = proc.call
+        while tok = @lexer.operator?(*operators)
+          rhs = proc.call
+          operator = Operator.from(tok.value)
+          expr = BinaryExpr.new(operator, expr, rhs)
+        end
+        expr
+      end
+
+      protected def parse_path_expr
+        if path = parse_absolute_location_path?
+          return path
+        end
+
+        if path = parse_relative_location_path?
+          return path
+        end
+
+        expr = parse_filter_expr
+        path = Path.filter(expr, [] of Step)
+
+        while tok = @lexer.current?
+          case tok.kind
+          when Kind::Slash
+            @lexer.next?
+            parse_relative_location_path(path)
+          when Kind::SlashSlash
+            @lexer.next?
+            path.steps << Step.abbreviated
+            parse_relative_location_path(path)
+          else
+            break
+          end
+        end
+
+        if path.steps.empty?
+          expr
+        else
+          path
+        end
+      end
+
+      def parse_absolute_location_path?
+        case @lexer.current.kind
+        when Kind::Slash
+          if @lexer.next?
+            path = Path.absolute([] of Step)
+            parse_relative_location_path(path)
+          else
+            Path.absolute
+          end
+        when Kind::SlashSlash
+          @lexer.next?
+          path = Path.absolute([Step.abbreviated])
+          parse_relative_location_path(path)
+        end
+      end
+
+      def parse_relative_location_path(path = nil)
+        parse_relative_location_path?(path) || syntax_error "Expected Path"
+      end
+
+      def parse_relative_location_path?(path = nil)
+        return path unless step = parse_step?
+
+        path ||= Path.relative([] of Step)
+        path.steps << step
+
+        while tok = @lexer.current?
+          case tok.kind
+          when Kind::Slash
+            @lexer.next?
+            path.steps << parse_step
+          when Kind::SlashSlash
+            @lexer.next?
+            path.steps << Step.abbreviated
+            path.steps << parse_step
+          else
+            break
+          end
+        end
+
+        path
+      end
+
+      protected def parse_step
+        parse_step? || syntax_error "Expected Step"
+      end
+
+      protected def parse_step?
+        return unless tok = @lexer.current?
+
+        case tok.kind
+        when Kind::Dot
+          @lexer.next?
+          Step.new(Axis::Self, NodeTest::Node.new, nil)
+        when Kind::DotDot
+          @lexer.next?
+          Step.new(Axis::Parent, NodeTest::Node.new, nil)
+        when Kind::AxisName
+          @lexer.next?
+          expect Kind::ColonColon
+          node_test = parse_node_test
+          predicates = parse_predicates?
+          Step.new(Axis.from(tok.value), node_test, predicates)
+        when Kind::At
+          @lexer.next?
+          node_test = parse_node_test
+          predicates = parse_predicates?
+          Step.new(Axis::Attribute, node_test, predicates)
+        else
+          if node_test = parse_node_test?
+            predicates = parse_predicates?
+            Step.new(Axis::Child, node_test, predicates)
+          end
+        end
+      end
+
+      protected def parse_node_test
+        parse_node_test? || syntax_error "Expected NodeTest"
+      end
+
+      protected def parse_node_test?
+        case (tok = @lexer.current).kind
+        when Kind::Star
+          @lexer.next?
+          NodeTest::Any.new
+        when Kind::Name
+          @lexer.next?
+          NodeTest::Name.new(tok.value)
+        when Kind::NodeType
+          @lexer.next?
+          case tok.value
+          when "node"
+            expect Kind::Lparen
+            expect Kind::Rparen
+            NodeTest::Node.new
+          when "text"
+            expect Kind::Lparen
+            expect Kind::Rparen
+            NodeTest::Text.new
+          when "comment"
+            expect Kind::Lparen
+            expect Kind::Rparen
+            NodeTest::Comment.new
+          when "processing-instruction"
+            expect Kind::Lparen
+            tok = @lexer.literal?
+            expect Kind::Rparen
+            NodeTest::ProcessingInstruction.new(tok.try(&.value))
+          else
+            raise "BUG: invalid NodeType"
+          end
+        end
+      end
+
+      protected def parse_filter_expr
+        expr = parse_primary_expr
+
+        if (tok = @lexer.current?) && (tok.kind == Kind::Lsqb)
+          predicate = parse_predicate
+          FilterExpr.new(expr, predicate)
+        else
+          expr
+        end
+      end
+
+      protected def parse_predicates
+        parse_predicates || syntax_error "Expected Predicate"
+      end
+
+      protected def parse_predicates?
+        predicates = nil
+        while (tok = @lexer.current?) && (tok.kind == Kind::Lsqb)
+          predicates ||= [] of Expr
+          predicates << parse_predicate
+        end
+        predicates
+      end
+
+      protected def parse_predicate
+        @lexer.next?
+        expr = parse_or_expr
+        expect Kind::Rsqb
+        expr
+      end
+
+      protected def parse_primary_expr
+        case (tok = @lexer.current).kind
+        when Kind::Literal
+          @lexer.next?
+          Literal.string(tok.value)
+        when Kind::Number
+          @lexer.next?
+          Literal.number(tok.value.to_f)
+        when Kind::FunctionName
+          @lexer.next?
+          arguments = parse_arguments
+          FunctionCall.new(tok.value, arguments)
+        when Kind::Lparen
+          @lexer.next?
+          expr = parse_or_expr
+          expect Kind::Rparen
+          expr
+        when Kind::VariableReference
+          @lexer.next?
+          VariableReference.new(tok.value)
+        else
+          syntax_error "Expected Literal, Number, FunctionCall, VariableReference or '('"
+        end
+      end
+
+      protected def parse_arguments
+        expect Kind::Lparen
+
+        if @lexer.current.kind == Kind::Rparen
+          @lexer.next?
+          return
+        end
+
+        args = [] of Expr
+
+        loop do
+          args << parse_or_expr
+
+          case @lexer.current.kind
+          when Kind::Rparen
+            @lexer.next?
+            return args
+          when Kind::Comma
+            @lexer.next?
+          else
+            syntax_error "Expected ',' or ')'"
+          end
+        end
+      end
+
+      protected def expect(kind : Kind)
+        if (tok = @lexer.current?) && tok.kind == kind
+          @lexer.next?
+        else
+          syntax_error "Expected #{kind} token"
+        end
+      end
+
+      protected def syntax_error(message = nil)
+        raise SyntaxError.new(message, @lexer.start_location)
+      end
+    end
+  end
+end


### PR DESCRIPTION
So far there's a `XML::XPath::Lexer` and `XML::XPath::Parser` to tokenize and parse a query into a general AST.